### PR TITLE
Feature change monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ OPTIONS:
   --dummy-display-size "width,height" The width & height of the dummy display
                              in pixels.
 
+  --drm-vout-display <drm-device>  The DRM display to use.\n\
+                             HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
+
   -h, --help                 Show this help and exit.
 
 EXAMPLES:

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2015,7 +2015,6 @@ valid_format:
             case 'i':  // --drm-vout-display
                 result_out->drm_vout_display = strdup(optarg);
                 if (result_out->drm_vout_display == NULL) {
-                    LOG_ERROR("Out of memory while parsing --drm-vout-display.\n");
                     return false;
                 }
                 if (!is_valid_drm_display(result_out->drm_vout_display)) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -141,7 +141,7 @@ OPTIONS:\n\
                              without a display attached.\n\
   --dummy-display-size \"width,height\" The width & height of the dummy display\n\
                              in pixels.\n\
-  --drm-vout-display         <drm-device> The DRM display to use.\n\
+  --drm-vout-display <drm-device>  The DRM display to use.\n\
                              HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
 \n\
   -h, --help                 Show this help and exit.\n\

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -264,6 +264,8 @@ struct flutterpi {
     bool session_active;
 
     char *desired_videomode;
+
+    char *drm_vout_display;
 };
 
 struct device_id_and_fd {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2119,7 +2119,9 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
     // find a GPU that has a primary node
     drmdev = NULL;
+    LOG_ERROR("*********************************** QWIEK ********************************** %d\n"));
     for (int i = 0; i < n_devices; i++) {
+        LOG_ERROR("Device %d: %s\n", i, devices[i]->nodes[DRM_NODE_PRIMARY]);
         drmDevicePtr device;
 
         device = devices[i];

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2138,7 +2138,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
             LOG_ERROR("Could not create drmdev from device at \"%s\". Continuing.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
         }   
-        x
+
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2126,22 +2126,32 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
         device = devices[i];
 
-        // if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
-        //     // We need a primary node.
-        //     LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
-        //     continue;
-        // }
+        //DISPLAY DEVICE SETTINGS
+        LOG_ERROR("Device \"%s\" has %d nodes.\n", device->nodes[DRM_NODE_PRIMARY], device->num_nodes);
+        for (int j = 0; j < device->num_nodes; j++) {
+            LOG_ERROR("Node %d: %s\n", j, device->nodes[j]);
+        }
+        LOG_ERROR("Device bus type: %d\n", device->bustype);
+        
+
+        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
+            // We need a primary node.
+            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
+            // continue;
+        }
 
         drmdev = drmdev_new_from_path(device->nodes[DRM_NODE_PRIMARY], &drmdev_interface, libseat);
         if (drmdev == NULL) {
             LOG_ERROR("Could not create drmdev from device at \"%s\". Continuing.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
-        }
+        }   
+        LOG_ERROR("DEVICE NAME: %s\n", connector->type);
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
-                // goto found_connected_connector;
+                
+                goto found_connected_connector;
             }
         }
 

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2140,7 +2140,7 @@ bool parse_drm_vout_display(const char *display, int *type_out, int *type_id_out
         *type_out = DRM_MODE_CONNECTOR_DSI;
         *type_id_out = 2;
     } else {
-        return false; // Ongeldige waarde
+        return false;
     }
     return true;
 }
@@ -2165,9 +2165,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
     // find a GPU that has a primary node
     drmdev = NULL;
-    LOG_ERROR("*********************************** QWIEK **********************************\n");
     for (int i = 0; i < n_devices; i++) {
-        LOG_ERROR("Device %d: %s\n", i, devices[i]->nodes[DRM_NODE_PRIMARY]);
         drmDevicePtr device;
 
         device = devices[i];
@@ -2175,7 +2173,6 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
             // We need a primary node.
-            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
         }
 
@@ -2185,28 +2182,20 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
             continue;
         }   
 
-
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
-                LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
-                LOG_ERROR("DEVICE NAME: %d\n", connector->type);
-                LOG_ERROR("DEVICE type id : %d\n", connector->type_id);
-
                 if (flutterpi->drm_vout_display != NULL) {
                     int expected_type, expected_type_id;
                     if (!parse_drm_vout_display(flutterpi->drm_vout_display, &expected_type, &expected_type_id)) {
-                        LOG_ERROR("Invalid DRM output specified: %s\n", flutterpi->drm_vout_display);
                         continue;
                     }
 
                     if (connector->type == expected_type && connector->type_id == expected_type_id) {
-                        LOG_ERROR("USING DISPLAY: %s\n", flutterpi->drm_vout_display);
                         goto found_connected_connector;
                     } else {
-                        continue; // Ga verder met de volgende connector
+                        continue; 
                     }
                 } else {
-                    LOG_ERROR("USING DEFAULT DISPLAY\n");
                     goto found_connected_connector;
                 }
             }
@@ -2407,7 +2396,6 @@ struct flutterpi *flutterpi_new_from_args(int argc, char **argv) {
         goto fail_free_fpi;
     }
 
-    // Sla de waarde van drm_vout_display op in fpi
     fpi->drm_vout_display = cmd_args.drm_vout_display ? strdup(cmd_args.drm_vout_display) : NULL;
 
 #ifndef HAVE_VULKAN

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2141,9 +2141,10 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
-                goto found_connected_connector;
+                // goto found_connected_connector;
             }
         }
+
         LOG_ERROR("Device \"%s\" doesn't have a display connected. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
         drmdev_unref(drmdev);
         continue;

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2125,13 +2125,6 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         drmDevicePtr device;
 
         device = devices[i];
-
-        //DISPLAY DEVICE SETTINGS
-        LOG_ERROR("Device \"%s\" has %d nodes.\n", device->nodes[DRM_NODE_PRIMARY], device->num_nodes);
-        for (int j = 0; j < device->num_nodes; j++) {
-            LOG_ERROR("Node %d: %s\n", j, device->nodes[j]);
-        }
-        LOG_ERROR("Device bus type: %d\n", device->bustype);
         
 
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2170,7 +2170,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
                 LOG_ERROR("DEVICE NAME: %d\n", connector->type);
                 LOG_ERROR("DEVICE type id : %d\n", connector->type_id);
-                if (cmd_args.drm_vout_display != NULL) {
+                if (flutterpi->drm_vout_display != NULL) {
                    LOG_ERROR("USING DISPLAY: %s\n", cmd_args.drm_vout_display);
                 } else {
                     LOG_ERROR("USING DEFAULT DISPLAY\n");
@@ -2378,6 +2378,9 @@ struct flutterpi *flutterpi_new_from_args(int argc, char **argv) {
     if (ok == false) {
         goto fail_free_fpi;
     }
+
+    // Sla de waarde van drm_vout_display op in fpi
+    fpi->drm_vout_display = cmd_args.drm_vout_display ? strdup(cmd_args.drm_vout_display) : NULL;
 
 #ifndef HAVE_VULKAN
     if (cmd_args.use_vulkan == true) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2169,7 +2169,6 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         drmDevicePtr device;
 
         device = devices[i];
-        
 
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
             // We need a primary node.
@@ -2180,11 +2179,12 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         if (drmdev == NULL) {
             LOG_ERROR("Could not create drmdev from device at \"%s\". Continuing.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
-        }   
+        }
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 if (flutterpi->drm_vout_display != NULL) {
+                    // We only want to use the display that was specified on the command line.
                     int expected_type, expected_type_id;
                     if (!parse_drm_vout_display(flutterpi->drm_vout_display, &expected_type, &expected_type_id)) {
                         continue;
@@ -2200,7 +2200,6 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
                 }
             }
         }
-
         LOG_ERROR("Device \"%s\" doesn't have a display connected. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
         drmdev_unref(drmdev);
         continue;

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2173,7 +2173,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
                 LOG_ERROR("DEVICE NAME: %d\n", connector->type);
                 LOG_ERROR("DEVICE type id : %d\n", connector->type_id);
                 if (flutterpi->drm_vout_display != NULL) {
-                   LOG_ERROR("USING DISPLAY: %s\n", cmd_args.drm_vout_display);
+                   LOG_ERROR("USING DISPLAY: %s\n", flutterpi->drm_vout_display);
                 } else {
                     LOG_ERROR("USING DEFAULT DISPLAY\n");
                 }

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -141,7 +141,8 @@ OPTIONS:\n\
                              without a display attached.\n\
   --dummy-display-size \"width,height\" The width & height of the dummy display\n\
                              in pixels.\n\
-  --drm-vout-display <drm-device> The DRM display to use.\n\
+  --drm-vout-display         <drm-device> The DRM display to use.\n\
+                             HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
 \n\
   -h, --help                 Show this help and exit.\n\
 \n\
@@ -2169,6 +2170,12 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
                 LOG_ERROR("DEVICE NAME: %d\n", connector->type);
                 LOG_ERROR("DEVICE type id : %d\n", connector->type_id);
+                if (cmd_args.drm_vout_display != NULL) {
+                   LOG_ERROR("USING DISPLAY: %s\n", cmd_args.drm_vout_display);
+                } else {
+                    LOG_ERROR("USING DEFAULT DISPLAY\n");
+                }
+
                 if (connector->type == DRM_MODE_CONNECTOR_DSI) {
                     goto found_connected_connector;
                 } else {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2127,11 +2127,11 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         device = devices[i];
         
 
-        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
-            // We need a primary node.
-            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
-            // continue;
-        }
+        // if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
+        //     // We need a primary node.
+        //     LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
+        //     // continue;
+        // }
 
         drmdev = drmdev_new_from_path(device->nodes[DRM_NODE_PRIMARY], &drmdev_interface, libseat);
         if (drmdev == NULL) {
@@ -2144,7 +2144,10 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
                 LOG_ERROR("DEVICE NAME: %d\n", connector->type);
-                goto found_connected_connector;
+                LOG_ERROR("DEVICE type id : %d\n", connector->type_id);
+                if (connector->type == DRM_MODE_CONNECTOR_DSI) {
+                    goto found_connected_connector;
+                }
             }
         }
 

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2138,12 +2138,12 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
             LOG_ERROR("Could not create drmdev from device at \"%s\". Continuing.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
         }   
-        LOG_ERROR("DEVICE NAME: %s\n", connector->type);
+        x
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
-                
+                LOG_ERROR("DEVICE NAME: %s\n", connector->type);
                 goto found_connected_connector;
             }
         }

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2143,7 +2143,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
                 LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
-                LOG_ERROR("DEVICE NAME: %s\n", connector->type);
+                LOG_ERROR("DEVICE NAME: %d\n", connector->type);
                 goto found_connected_connector;
             }
         }

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2119,18 +2119,18 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
     // find a GPU that has a primary node
     drmdev = NULL;
-    LOG_ERROR("*********************************** QWIEK ********************************** %d\n");
+    LOG_ERROR("*********************************** QWIEK **********************************\n");
     for (int i = 0; i < n_devices; i++) {
         LOG_ERROR("Device %d: %s\n", i, devices[i]->nodes[DRM_NODE_PRIMARY]);
         drmDevicePtr device;
 
         device = devices[i];
 
-        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
-            // We need a primary node.
-            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
-            continue;
-        }
+        // if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
+        //     // We need a primary node.
+        //     LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
+        //     continue;
+        // }
 
         drmdev = drmdev_new_from_path(device->nodes[DRM_NODE_PRIMARY], &drmdev_interface, libseat);
         if (drmdev == NULL) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2173,11 +2173,11 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
         device = devices[i];
         
 
-        // if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
-        //     // We need a primary node.
-        //     LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
-        //     // continue;
-        // }
+        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
+            // We need a primary node.
+            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
+            continue;
+        }
 
         drmdev = drmdev_new_from_path(device->nodes[DRM_NODE_PRIMARY], &drmdev_interface, libseat);
         if (drmdev == NULL) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2128,6 +2128,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
             // We need a primary node.
+            LOG_ERROR("Device \"%s\" doesn't have a primary node. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
             continue;
         }
 
@@ -2139,6 +2140,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
+                LOG_ERROR("Device \"%s\" has a display connected.\n", device->nodes[DRM_NODE_PRIMARY]);
                 goto found_connected_connector;
             }
         }

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2119,7 +2119,7 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
     // find a GPU that has a primary node
     drmdev = NULL;
-    LOG_ERROR("*********************************** QWIEK ********************************** %d\n"));
+    LOG_ERROR("*********************************** QWIEK ********************************** %d\n");
     for (int i = 0; i < n_devices; i++) {
         LOG_ERROR("Device %d: %s\n", i, devices[i]->nodes[DRM_NODE_PRIMARY]);
         drmDevicePtr device;

--- a/src/flutter-pi.h
+++ b/src/flutter-pi.h
@@ -141,6 +141,8 @@ struct flutterpi_cmdline_args {
 
     bool dummy_display;
     struct vec2i dummy_display_size;
+
+    char *drm_vout_display;
 };
 
 int flutterpi_fill_view_properties(bool has_orientation, enum device_orientation orientation, bool has_rotation, int rotation);


### PR DESCRIPTION
## Add `--drm-vout-display` Parameter for Selecting Specific DRM Outputs

This pull request introduces a new command-line parameter, `--drm-vout-display`, to allow users to specify the desired DRM output display when running Flutter applications on Raspberry Pi. 

This change is implemented in response to [issue #201](https://github.com/ardera/flutter-pi/issues/201).

### Supported Options
The supported values for this parameter are:
- `HDMI-A-1`
- `HDMI-A-2`
- `DSI-1`
- `DSI-2`

If the `--drm-vout-display` parameter is not provided, the code will behave as before, automatically selecting the first available connected display.

---

### Key Changes

#### New Command-Line Argument
- Added the `--drm-vout-display` option to the command-line arguments.
- Users can now specify the desired display output by providing one of the supported values.

#### Validation and Parsing
- The provided value is validated against the supported options (`HDMI-A-1`, `HDMI-A-2`, `DSI-1`, `DSI-2`).
- The `flutterpi` struct now includes a `drm_vout_display` field to store the selected display.

#### Behavior
- If a valid display is specified, the code will attempt to use the corresponding DRM connector type and type ID.
- If no display is specified, the code defaults to the previous behavior of selecting the first available connected display.

#### Documentation
- Updated the `--help` output to include the new `--drm-vout-display` option.
- The supported values are based on the Raspberry Pi documentation: **Playing Audio and Video**.

---

### Example Usage
```sh
flutter-pi --drm-vout-display HDMI-A-1
```

---

### Backward Compatibility
This change is fully backward-compatible. If the `--drm-vout-display` parameter is not provided, the application will function as it did previously, automatically selecting the first available connected display.

---

### Motivation
This feature provides users with greater control over which display output is used, especially in multi-display setups or when specific outputs are required for certain use cases.
